### PR TITLE
164859742 Configure postgres as the database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ ENV/
 
 # SQLite3
 db.sqlite3
+
+#vscode
+.vscode

--- a/.sample.env
+++ b/.sample.env
@@ -1,0 +1,5 @@
+export DBNAME='databse_name'
+export DBUSER='databse_user'
+export DBPASSWORD='password'
+export DBHOST='localhost'
+export DBPORT='your db port'

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -81,8 +81,12 @@ WSGI_APPLICATION = 'authors.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': os.getenv('DBNAME'),
+        'USER': os.getenv('DBUSER'),
+        'PASSWORD': os.getenv('DBPASSWORD'),
+        'HOST': os.getenv('DBHOST'),
+        'PORT': os.getenv('DBPORT'),
     }
 }
 


### PR DESCRIPTION
### What does this PR do?

* Configures the API to use Postgres as the DB

### Description of Task to be completed?

- [x] Configure Authors Haven to use PostgreSQL as DB Engine

### How should this be manually tested?

1. Clone the repo to your local machine [here](https://github.com/deferral/ah-django.git) 

2. cd into ah-django and checkout to the branch ```ch-postgresql-config-164859742```

       cd ah-django
       git checkout ch-postgresql-config-164859742

3. Create and activate a virtual environment:

       python3 -m virtualenv venv

       source venv/bin/activate

 * If you need to install virtualenv first:

       pip install virtualenv

4. Install the project dependencies

       pip install -r requirements.txt 

5. Export the following variables to the environment. Remember to replace the variables with your own:

       export DBNAME='databse_name'
       export DBUSER='databse_user'
       export DBPASSWORD='password'
       export DBHOST='localhost'
       export DBPORT='your postgres port'

   Alternatively, create a .env file that follows the sample in the main directory of the project.

6. Make database migrations and start the django server

       python3 manage.py makemigrations

       python3 manage.py migrate

Check your Postgres database for tables, you should be able to see newly created tables in the formerly empty database

### Any background context you want to provide?

Initially, the application was running on an SqlLite3 Database

### What are the relevant pivotal tracker stories?

#2 