### PR TITLE
#164859741 Add Travis CI badge to ReadMe file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+python:
+  - 3.6
+
+# install dependancies
+install:
+  - pip install -r requirements.txt
+  - pip install coveralls
+  - pip install coverage
+
+# run tests
+script:
+  - coverage run --source=authors.apps ./manage.py test
+
+after_success:
+  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: python
+python:
+  - 3.6
+
+# install dependancies
+install:
+  - pip install -r requirements.txt
+  - pip install coveralls
+  - pip install coverage
+
+services:
+  - postgresql
+
+before_script:
+  - psql -c 'create database djangodb;' -U postgres
+
+# run tests
+script:
+  - coverage run --source=authors.apps ./manage.py test
+
+after_success:
+  - coveralls

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Coverage Status](https://coveralls.io/repos/github/deferral/ah-django/badge.svg?branch=develop)](https://coveralls.io/github/deferral/ah-django?branch=develop)
+
 Authors Haven - A Social platform for the creative at heart.
 =======
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.com/deferral/ah-django.svg?branch=develop)](https://travis-ci.com/deferral/ah-django)
+
 Authors Haven - A Social platform for the creative at heart.
 =======
 


### PR DESCRIPTION
### What does this PR do?
Add Travis CI integration
### Description of Task to be completed?
- [x] Set up Travis account
- [x] Add a mark up to the repo README.MD
### How should this be manually tested?
* Access the repository on GitHub from [here](https://github.com/deferral/ah-django)
* Switch to the branch ch-travis-intergration-164859741 
* You should see a building badge on the readme file
### Any background context you want to provide?
None
### What are the relevant pivotal tracker stories?
[#164859741](https://www.pivotaltracker.com/story/show/164859741)