### PR TITLE
#164859768 Comment History 

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,6 @@
 [run]
  omit =
     *migrations*
+    *manage.py
+    *apps.py
     

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,11 @@ addons:
 
 before_script:
   - psql -c 'create database djangodb;' -U postgres
+  - python manage.py makemigrations
+  - python manage.py migrate
 
 script:
-  - ./manage.py makemigrations
-  - ./manage.py migrate
-  - pytest --cov=authors.apps
+  - coverage run --source='.' -m pytest auth*/apps/  && coverage report -m
 
 after_success:
   - coveralls

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 from . import models
 from ..comments.models import Comment
+from ..comments.serializers import CommentSerializer
 from django.db.models import Avg
 
 
@@ -57,10 +58,9 @@ class ArticleSerializer(serializers.ModelSerializer):
         return inst.user_reaction.fetch_popularity_status(avg=True)
 
     def get_comments(self, inst):
-        query = Comment.objects.filter(article=inst).values()
-        return [
-            (comment.get('id'), comment.get('body')) for comment in list(query)
-        ]
+
+        query = Comment.objects.filter(article=inst)
+        return CommentSerializer(query, many=True).data
 
     def __repr__(self):
         return self.body

--- a/authors/apps/comments/models.py
+++ b/authors/apps/comments/models.py
@@ -1,6 +1,8 @@
 from django.db import models
 from django.db.models.signals import post_save
 
+from simple_history.models import HistoricalRecords
+
 from authors.apps.articles.models import Article
 from authors.apps.authentication.models import User
 from authors.apps.notifications.signals import commented_on
@@ -24,6 +26,7 @@ class Comment(models.Model):
 
     def __repr__(self):
         return self.body
+    comment_history = HistoricalRecords()
 
     class Meta:
         order_with_respect_to = 'article'
@@ -35,8 +38,11 @@ class Comment(models.Model):
             Gives replies made to a comment
         """
         queryset = CommentReply.objects.filter(
-            comment_to__body=self.body).values()
-        return [item.get('body') for item in list(queryset)]
+            comment_to__body=self.body)
+
+        # return [
+        #    (item.get('id'), item.get('body')) for item in list(queryset)]
+        return queryset
 
 
 class CommentReply(models.Model):

--- a/authors/apps/comments/serializers.py
+++ b/authors/apps/comments/serializers.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 from authors.apps.comments.models import Comment, CommentReply
+from authors.apps.core.history import ModelHistory
 
 import re
 
@@ -41,7 +42,7 @@ class CommentSerializer(serializers.ModelSerializer):
         return inst.article.slug
 
     def get_replies(self, inst):
-        return inst.replies
+        return CommentReplySerializer(inst.replies, many=True).data
 
     def get_likes(self, inst):
         return inst.user_reaction.likes.count()
@@ -70,3 +71,21 @@ class CommentReplySerializer(serializers.ModelSerializer):
 
     def get_article(self, inst):
         return inst.article.title
+
+
+class CommentHistorySerializer(serializers.ModelSerializer):
+    comment_history = serializers.SerializerMethodField()
+    comment_id = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Comment
+        fields = ('comment_id', 'comment_history')
+
+    def get_comment_history(self, inst):
+        return hist.get_update_records(inst.comment_history)
+
+    def get_comment_id(self, inst):
+        return inst.id
+
+
+hist = ModelHistory()

--- a/authors/apps/comments/tests/comment_test.py
+++ b/authors/apps/comments/tests/comment_test.py
@@ -153,3 +153,21 @@ class TestComment(CommentsBaseTestCase):
 
         self.assertIn("Provide a readable comment, cool?",
                       res.json().get('comments') .get('errors').get('body')[0])
+
+    def test_retrieve_comment_history(self):
+        """
+            Validate: History records of comments can be seen
+        """
+        comment_path = self.get_single_comment_path()
+        path = self.get_article_slug(created=True)
+        self.post_article_comment(path)
+
+        self.client.post(f'{path}/{comment_path}',
+                         data=self.comment, format='json')
+
+        resp = self.client.get(
+            f'{path}/{comment_path}/history')
+
+        self.assertIn('comment_history',
+                      resp.json().get('comments').keys(),
+                      )

--- a/authors/apps/comments/urls.py
+++ b/authors/apps/comments/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 
-from .views import CommentAPIView, ListCommentsView, ReplyList, ReplyAPIView
+from .views import (CommentAPIView, ListCommentsView,
+                    ReplyList, ReplyAPIView, CommentHistoryAPIView)
 
 app_name = 'comments'
 
@@ -8,6 +9,9 @@ urlpatterns = [
     path('articles/<slug:slug>/comments',
          ListCommentsView.as_view(),
          name='all-comments'),
+    path('articles/<slug:slug>/comments/<int:key>/history',
+         CommentHistoryAPIView.as_view(),
+         name='comment_history'),
     path('articles/<slug:slug>/comments/<int:id>',
          CommentAPIView.as_view(),
          name='single-comment'),
@@ -17,4 +21,5 @@ urlpatterns = [
     path('articles/<slug:slug>/comments/<int:id>/reply/<int:key>',
          ReplyAPIView.as_view(),
          name='comment-reply'),
+
 ]

--- a/authors/apps/core/history.py
+++ b/authors/apps/core/history.py
@@ -1,0 +1,49 @@
+"""
+    This module holds a helper class for
+    retireving of model history records
+"""
+from django.db.models import Q
+
+from authors.apps.comments.models import Comment
+
+
+class ModelHistory:
+    """
+        Makes record responses to requests
+        of item histories
+    """
+
+    def get_update_records(self, instance):
+        """
+            Retrieves the editing history of
+            a comment custom in JSON form
+        """
+        records = []
+
+        update = '~'
+        create = '+'
+        for record in list(instance.filter(
+                Q(history_type=create) | Q(history_type=update))):
+            history_data = {
+                "body": self.retreive_body(record),
+                "alter_date": str(record.history_date),
+                "change_type": self.get_worded_history(record.history_type),
+                "history_id": record.history_id
+            }
+            records.append(history_data)
+        return records
+
+    def retreive_body(self, rec):
+        """
+            Returns the body field of a comment
+            item
+        """
+        return rec.body if rec in Comment.comment_history.all() \
+            else rec.reply_to
+
+    def get_worded_history(self, symbol):
+        """
+            Returns a word definition of the
+            history change type from the history symbol
+        """
+        return 'edited' if symbol == '~' else 'created'

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -52,6 +52,7 @@ INSTALLED_APPS = [
     'drf_yasg',
     'django_inlinecss',
     'social_django',
+    'simple_history',
     'cloudinary',
     'notifications',
     'django_filters',
@@ -83,6 +84,7 @@ TEMPLATES = [
                 'django.contrib.messages.context_processors.messages',
                 'social_django.context_processors.backends',
                 'social_django.context_processors.login_redirect',
+                'simple_history.middleware.HistoryRequestMiddleware',
             ],
         },
     },
@@ -169,8 +171,8 @@ REST_FRAMEWORK = {
     'PAGE_SIZE': 5
 }
 
-# EMAIL_BACKEND = 'sendgrid_backend.SendgridBackend'
-EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_BACKEND = 'sendgrid_backend.SendgridBackend'
+# EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST = os.environ.get('EMAIL_HOST')
 EMAIL_PORT = os.environ.get('EMAIL_PORT') or 587
 EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD')

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ django-inlinecss==0.1.2
 django-model-utils==3.1.2
 django-notifications-hq==1.5.0
 django-sendgrid-v5==0.7.1
+django-simple-history==2.7.0
 djangorestframework==3.9.2
 djangorestframework-filters==0.11.1
 djangorestframework-jwt==1.11.0
@@ -58,6 +59,7 @@ mock==2.0.0
 more-itertools==6.0.0
 nose==1.3.7
 oauthlib==3.0.1
+pathlib2==2.3.3
 pbr==5.1.3
 Pillow==5.4.1
 pluggy==0.9.0
@@ -91,7 +93,6 @@ singledispatch==3.4.0.3
 six==1.10.0
 social-auth-app-django==3.1.0
 social-auth-core==3.1.0
-six==1.10.0
 soupsieve==1.9
 typed-ast==1.3.1
 uritemplate==3.0.0


### PR DESCRIPTION
#### What does this PR do?
- Track comment history
#### Description of Task to be completed?
 - [X] Record comment status on each save
- [X] View history records of a comment

#### How should this be manually tested?
1. Access a clone copy of the repo from [here](https://github.com/andela/ah-django)
```shell
$ git clone https://github.com/andela/ah-django
```
2. Checkout the this feature branch
```shell
$ git checkoutft-comment-history-164859768
```
3. Create a virtual environment and activate it
```shell
$ pip install virtualenv && virtualenv venv && source venv/bin/activate
```
- Should your pip default to python2, you can create a python3 environent by running
 `virtualenv -p python3 venv` or simply use `pip3` if you have it installed
4. Install the project dependencies
```shell
$ pip install -r requirements.txt
```
5. Use the `.env_sample` to create an `.env` file with environment variables then source the .env.
The `env_sample` details out the required environment vairables. Copy them and paste in an `env` file. Export the environment variables with the command:
```
$ source .env
```

6. Make database migrations and start the django server
```shell
$ python3 manage.py makemigrations
$ python3 manage.py migrate
$ python3 manage.py runserver
```

7. Testing the endpoint
- First create an article by sending a `POST` request to the endpoint `127.0.0.1:8000/api/articles/`
```shell
"article": {
                "title": "Funny thing on the keyboard",
                "description": "Suggestions for the name of that funny thing",
                "body": "Now how do we go about this thing..."
            }
        }


```
- Use the slug from the response data in accessing the comments endpoints
Post a comment to the article: `POST` `127.0.0.1:8000/api/articles/<slug>/comment`
```shell

{
	"comment":
	{
		"body": "The tables are stickier"
		
	}
}

```
- Edit the comment: `PUT` `127.0.0.1:8000/api/articles/<:slug>/comments/<:comment_id>`
Send the data in the same format as the `POST` request.
This step isn't necessary, but if omitted, the comment will have a single `create` history

- Access the comment history at the endpoint
 `GET`:  `127.0.0.1:8000/api/articles/<:slug>/comments/<:comment_id>/history`

#### Any background context you want to provide?
None

#### What are the relevant pivotal tracker stories?
[#164859768](https://www.pivotaltracker.com/story/show/164859768)


