### PR TITLE
164859764 implement social sharing of articles

### DIFF
--- a/authors/apps/articles/tests/article_test.py
+++ b/authors/apps/articles/tests/article_test.py
@@ -1,0 +1,239 @@
+from rest_framework import status
+from django.urls import reverse
+from ...authentication.tests.base_test import BaseTestCase
+from rest_framework_jwt import utils
+from ..serializers import ArticleSerializer
+from ..models import Article
+
+
+class TestNewArticle(BaseTestCase):
+    """
+        New article tests
+    """
+
+    def test_auth_required(self):
+        """
+            auth required to post article
+        """
+        new_article = {
+            "article": {
+                "title": "How to train your dragon",
+                "description": "Ever wonder how?",
+                "body": "It takes a Jacobian",
+                "tagList": [
+                    "dragons",
+                    "training"
+                ]
+            }
+        }
+
+        response = self.client.post(self.new_article_path,
+                                    new_article, format='json')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_create_new(self):
+        """
+        create new article successfuly
+        """
+        new_article = {
+            "article": {
+                "title": "How to train your dragon",
+                "description": "Ever wonder how?",
+                "body": "It takes a Jacobian",
+                "tagList": [
+                    "dragons",
+                    "training"
+                ]
+            }
+        }
+
+        payload = utils.jwt_payload_handler(self.testuser)
+        token = utils.jwt_encode_handler(payload)
+        auth = 'Bearer {0}'.format(token)
+        response = self.client.post(self.new_article_path,
+                                    new_article, HTTP_AUTHORIZATION=auth,
+                                    format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+
+class ArticleDetails(BaseTestCase):
+    """
+        Test getting, updating, deleting articles
+    """
+
+    def test_get_all_articles(self):
+        """
+        test get all articles
+        """
+        response = self.client.get(self.articles_feed)
+        # articles = Article.objects.all()
+        # serializer = ArticleSerializer(articles, many=True)
+        # self.assertEqual(response.data, serializer.data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_get_one_article(self):
+        """
+        test get one article
+        """
+        response = self.client.get(self.article_details)
+        articles = Article.objects.get(slug='test-slug')
+        serializer = ArticleSerializer(articles)
+        self.assertEqual(response.data, serializer.data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_update_article(self):
+        """
+        test update article
+        """
+        update_article = {
+            "title": "How to train your dragon -- update",
+            "description": "Ever wonder how?",
+            "body": "It takes a Jacobian",
+            "tagList": [
+                "dragons",
+                "training"
+            ]
+        }
+
+        payload = utils.jwt_payload_handler(self.testuser)
+        token = utils.jwt_encode_handler(payload)
+        auth = 'Bearer {0}'.format(token)
+        response = self.client.put(self.article_details,
+                                   update_article, HTTP_AUTHORIZATION=auth,
+                                   format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_invalid_update_article(self):
+        """
+        test update article unauthorized
+        """
+        update_article = {
+            "title": "How to train your dragon -- update",
+            "description": "Ever wonder how?",
+            "body": "It takes a Jacobian",
+            "tagList": [
+                "dragons",
+                "training"
+            ]
+        }
+        response = self.client.put(self.article_details,
+                                   update_article, format='json')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_delete_article(self):
+        """
+        test delete article
+        """
+        payload = utils.jwt_payload_handler(self.testuser)
+        token = utils.jwt_encode_handler(payload)
+        auth = 'Bearer {0}'.format(token)
+        response = self.client.put(self.article_details,
+                                   HTTP_AUTHORIZATION=auth)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_invalid_delete_article(self):
+        """
+        test delete article unauthorized
+        """
+        response = self.client.put(self.article_details)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_rate_article(self):
+        """
+        test rate article
+        """
+        rating = {
+            "rating": {
+                "rating": 4
+            }
+        }
+
+        payload = utils.jwt_payload_handler(self.testuser)
+        token = utils.jwt_encode_handler(payload)
+        auth = 'Bearer {0}'.format(token)
+        response = self.client.post(self.article_rating,
+                                    rating, HTTP_AUTHORIZATION=auth,
+                                    format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_invalid_rate_article(self):
+        """
+        test rate article invalid
+        """
+        rating = {
+            "rating": {
+                "rating": 23
+            }
+        }
+
+        payload = utils.jwt_payload_handler(self.testuser)
+        token = utils.jwt_encode_handler(payload)
+        auth = 'Bearer {0}'.format(token)
+        response = self.client.post(self.article_rating,
+                                    rating, HTTP_AUTHORIZATION=auth,
+                                    format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_sharing_on_twitter(self):
+        """
+        test the sharing of an article on twitter
+         """
+        payload = utils.jwt_payload_handler(self.testuser)
+        token = utils.jwt_encode_handler(payload)
+        auth = 'Bearer {0}'.format(token)
+        response = self.client.get(reverse('articles:share', kwargs={
+            'slug': 'test-slug', 'platform': 'twitter'
+        }),
+            HTTP_AUTHORIZATION=auth,
+            format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_sharing_on_facebook(self):
+        """
+        test the sharing of an article on facebook
+         """
+        payload = utils.jwt_payload_handler(self.testuser)
+        token = utils.jwt_encode_handler(payload)
+        auth = 'Bearer {0}'.format(token)
+        response = self.client.get(reverse('articles:share', kwargs={
+            'slug': 'test-slug', 'platform': 'facebook'
+        }),
+            HTTP_AUTHORIZATION=auth,
+            format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_sharing_on_reddit(self):
+        """
+        test the sharing of an article on reddit
+         """
+        payload = utils.jwt_payload_handler(self.testuser)
+        token = utils.jwt_encode_handler(payload)
+        auth = 'Bearer {0}'.format(token)
+        response = self.client.get(reverse('articles:share', kwargs={
+            'slug': 'test-slug', 'platform': 'reddit'
+        }),
+            HTTP_AUTHORIZATION=auth,
+            format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_sharing_on_linkedin(self):
+        """
+        test the sharing of an article on linkedin
+         """
+
+        payload = utils.jwt_payload_handler(self.testuser)
+        token = utils.jwt_encode_handler(payload)
+        auth = 'Bearer {0}'.format(token)
+        response = self.client.get(reverse('articles:share', kwargs={
+            'slug': 'test-slug', 'platform': 'linkedin'
+        }),
+            HTTP_AUTHORIZATION=auth,
+            format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def search_article_title_success(self):
+        """ test for a successful search for article by title"""
+        response = self.test_client.get(
+            "/api/articles/search?title={}".format(self.title),
+            content_type='application/json')
+        self.assertEqual(response.status_code, 200)

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import url
 
 from .views import (
     ArticleList, ArticleDetails, NewArticle, RateArticle,
-    SearchArticlesList
+    SearchArticlesList, ShareArticlesApiView
 )
 
 
@@ -13,8 +13,10 @@ urlpatterns = [
         SearchArticlesList.as_view(), name='article_title'),
     url(r'^articles/$', NewArticle.as_view(), name='new_article'),
     url(r'^articles/feed/$', ArticleList.as_view(), name='articles_feed'),
+    url(r'^articles/(?P<slug>.+)/share/(?P<platform>.+)/$',
+        ShareArticlesApiView.as_view(), name='share'),
     url(r'^articles/(?P<slug>.+)/rate/$', RateArticle.as_view(),
         name='rate_article'),
     url(r'^articles/(?P<slug>.+)/$', ArticleDetails.as_view(),
-        name='article_details')
+        name='article_details'),
 ]

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -55,6 +55,7 @@ INSTALLED_APPS = [
     'social_django',
     'simple_history',
     'cloudinary',
+    'django_social_share',
     'notifications',
     'django_filters',
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ django-model-utils==3.1.2
 django-notifications-hq==1.5.0
 django-sendgrid-v5==0.7.1
 django-simple-history==2.7.0
+django-social-share==1.3.2
 djangorestframework==3.9.2
 djangorestframework-filters==0.11.1
 djangorestframework-jwt==1.11.0


### PR DESCRIPTION
### What does this PR do?

Implement social sharing

### Description of Task to be completed?

- [x] Write tests for the endpoints for social sharing endpoints
- [x] Plugin the django-social-sharing app
- [x] Write views for social sharing

### How should this be manually tested?

1. Clone the repo to your local machine from [here](https://github.com/deferral/ah-django.git)
2. cd into the ah-django directory and checkout to the branch ```ft-social-sharing-164859764```

       cd ah-django

       git checkout ft-social-sharing-164859764

2. Create a virtual environment and activate it:

       python3 -m virtualenv venv && source venv/bin/activate

 * If you need to install virtualenv first:

       pip install virtualenv

4. Install the project dependencies

       pip install -r requirements.txt

5. Make database migrations and start the django server

       python3 manage.py makemigrations

       python3 manage.py migrate
 
       python3 manage.py runserver 

6. In your test client, send a get request to ```http://127.0.0.1:8000/api/articles/<article-slag/share/<platform-you-want-to-share-to>/```

        platforms are limited to Facebook, Twitter, Reddit and Linkedin

8. You should be able to receive a link for sharing to any of the above-listed platforms.

### Any background context you want to provide?

Sharing is valid for exiting articles. Users must be logged in to share articles.

### What are the relevant pivotal tracker stories?
[#164859764](https://www.pivotaltracker.com/story/show/164859764)