### PR TITLE
#165558519 A user can toggle notifications

### DIFF
--- a/authors/apps/authentication/serializers.py
+++ b/authors/apps/authentication/serializers.py
@@ -195,3 +195,28 @@ class SocialAuthSerializer(serializers.Serializer):
     access_token = serializers.CharField(required=True, trim_whitespace=True)
     access_token_secret = serializers.CharField(
         max_length=300, allow_null=True, default=None, trim_whitespace=True)
+
+
+class ToggleNotificationSerializer(serializers.ModelSerializer):
+    """
+    This class allows user to toggle email notifications on
+    and off
+    """
+
+    class Meta:
+        model = User
+        fields = [
+            'email_notification'
+        ]
+
+    def update(self, instance, validated_data):
+        """
+        Updates the email notification field
+        """
+
+        instance.email_notification = validated_data.get(
+            'email_notification',
+            instance.email_notification
+        )
+        instance.save()
+        return instance

--- a/authors/apps/authentication/templates/toggle_notification.html
+++ b/authors/apps/authentication/templates/toggle_notification.html
@@ -1,0 +1,9 @@
+{% extends 'emailing_template.html' %}
+{% block body %}
+    <div id="email-verification">
+        <p id="greeting">Email Notifications</p>
+            <div class="failed-button">
+                <p>Your notifications have been turned {{ notification }}</p>
+            </div>
+    </div>
+{% endblock %}

--- a/authors/apps/authentication/tests/base_test.py
+++ b/authors/apps/authentication/tests/base_test.py
@@ -31,6 +31,7 @@ class BaseTestCase(APITestCase):
         self.new_article_path = reverse('articles:new_article')
         self.articles_feed = reverse('articles:articles_feed')
         self.profile_url = reverse('profiles:list_profiles')
+        self.togglenot = reverse('notifications:read-notifications')
 
         self.view_reports = reverse('articles:view_reports')
         self.username = 'testguy99'
@@ -109,6 +110,15 @@ class BaseTestCase(APITestCase):
                 'password': 'badA55mammal!'
             }
         }
+
+        self.toggle_on = {
+            "email_notification": True
+        }
+
+        self.toggle_off = {
+            "email_notification": False
+        }
+
         self.google_social_auth = {
             "token_provider": "google-oauth2",
             "access_token": 'access_token'

--- a/authors/apps/authentication/urls.py
+++ b/authors/apps/authentication/urls.py
@@ -4,7 +4,7 @@ from django.urls import path
 from .views import (
     LoginAPIView, RegistrationAPIView, UserRetrieveUpdateAPIView,
     ForgotPasswordAPIview, ResetPasswordAPIView,
-    SocialAuth, VerifyUserAPIView
+    SocialAuth, VerifyUserAPIView, NotifytoggleAPIView
 )
 app_name = 'authentication'
 
@@ -12,6 +12,8 @@ app_name = 'authentication'
 urlpatterns = [
     url(r'^user/?$', UserRetrieveUpdateAPIView.as_view()),
     url(r'^users/login/?$', LoginAPIView.as_view(), name="login"),
+    url(r'^users/notifications/toggle/(?P<string>[\w\-]+)/?$',
+        NotifytoggleAPIView.as_view(), name='notifytoggle'),
     url(r'^account/forgot_password/?$',
         ForgotPasswordAPIview.as_view(), name="forgot_password"),
     url(r'^account/reset_password/?(?P<token>[a-zA-Z0-9_\.-]{3,1000})?/?$',

--- a/authors/apps/notifications/tests/test_notifications.py
+++ b/authors/apps/notifications/tests/test_notifications.py
@@ -81,3 +81,60 @@ class NotificationConsumerTest(BaseTestCase):
         response = await communicator.receive_from()
         self.assertEqual(response, "hello")
         await communicator.disconnect()
+
+    def test_toggle_on_notification(self):
+        """ Test toggle on notification """
+
+        with self.settings(
+                EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend'):
+            res = self.register_new_user(data=self.user3)
+        token = res.data['data']['token']
+        auth = 'Bearer {}'.format(token)
+        url = self.registration_path + "/notifications/toggle/purple"
+        response = self.client.patch(
+            url,
+            self.toggle_on,
+            HTTP_AUTHORIZATION=auth
+        )
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_200_OK
+        )
+
+    def test_toggle_off_notification(self):
+        """ Test toggle on notification """
+
+        with self.settings(
+                EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend'):
+            res = self.register_new_user(data=self.user3)
+        token = res.data['data']['token']
+        auth = 'Bearer {}'.format(token)
+        url = self.registration_path + "/notifications/toggle/purple"
+        response = self.client.patch(
+            url,
+            self.toggle_off,
+            HTTP_AUTHORIZATION=auth
+        )
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_200_OK
+        )
+
+    def test_toggle_notification_failure(self):
+        """ Test unauthorized notification toggle """
+
+        with self.settings(
+                EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend'):
+            res = self.register_new_user(data=self.user3)
+        token = res.data['data']['token']
+        auth = 'Bearer {}'.format(token)
+        url = self.registration_path + "/notifications/toggle/yellow"
+        response = self.client.patch(
+            url,
+            self.toggle_on,
+            HTTP_AUTHORIZATION=auth
+        )
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_403_FORBIDDEN
+        )


### PR DESCRIPTION
### What does this PR do?

Toggles notifications on and off

### Description of Task to be completed?

- [x] Write tests for the endpoint
- [x] Allow user to turn notifications on and off

### How should this be manually tested?

1. Clone the repo to your local machine from [here](https://github.com/deferral/ah-django.git)
2. cd into the ah-django directory
Create a virtual environment and activate it:

       python3 -m virtualenv venv && source venv/bin/activate
       pip install virtualenv

4. Install the project dependencies

       pip install -r requirements.txt

5. Make database migrations and start the django server

       python3 manage.py makemigrations

       python3 manage.py migrate
 
       python3 manage.py runserver 

6. In your test client, register two new accounts by sending POST requests to 
```
http://127.0.0.1:8000/api/users
```
7. Then use the given token to create activities for each of the accounts. For example, use each of the accounts to follow the other.
8. For each of the account, you should be able to email notifications of the respective activity streams. These include following backs, article creations for accounts that are followed and comments on articles that accounts have authored.
9. Navigate to the endpoint `localhost:8000/api/users/notifications/toggle/<username>` then in postman, make the following request:
```
{
"email_notification": false
	
}
```

### What are the relevant pivotal tracker stories?

                     #164859759