### PR TITLE
#165631652 add validation to return 409 on duplicates

### DIFF
--- a/authors/apps/articles/tests/article_test.py
+++ b/authors/apps/articles/tests/article_test.py
@@ -59,6 +59,12 @@ class TestNewArticle(BaseTestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         cloudinary.uploader.destroy('ah-django/test_testguy99')
 
+        # run again to test duplicate returns 409
+        response = self.client.post(self.new_article_path,
+                                    new_article, HTTP_AUTHORIZATION=auth,
+                                    format='json')
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+
     def test_create_new_with_invalid_image(self):
         """
         create new article successfuly

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -57,6 +57,12 @@ class NewArticle(APIView):
         article = request.data.get('article', {})
         article['slug'] = \
             slugify(article['title']) + "_" + request.user.username
+        try:
+            Article.objects.get(slug=article['slug'])
+            return Response({"error": "an article with that slug exists"},
+                            status.HTTP_409_CONFLICT)
+        except Article.DoesNotExist:
+            pass
         article['reading_time'] = self.calculate_read_time(article['body'])
         try:
             image_path = Path(article['image'])

--- a/authors/apps/authentication/tests/test_user.py
+++ b/authors/apps/authentication/tests/test_user.py
@@ -1,12 +1,13 @@
 """
     This test module holds tests related to user accounts
 """
-from django.test import TestCase
+from rest_framework import status
 
+from .base_test import BaseTestCase
 from authors.apps.authentication.models import User
 
 
-class UserModelTest(TestCase):
+class UserModelTest(BaseTestCase):
     """
     Test for creating a new user account
     """
@@ -19,3 +20,30 @@ class UserModelTest(TestCase):
             User.objects.create_user(username="jmehere",
                                      email="j@mehere.com",
                                      password="password"), User)
+
+        data1 = {
+            "user": {
+                "username": "jmehere",
+                "email": "j1@mehere.com",
+                "password": "password"
+                }
+            }
+
+        data2 = {
+            "user": {
+                "username": "jmehere1",
+                "email": "j@mehere.com",
+                "password": "password"
+                }
+            }
+
+        # test duplicate returns 409
+        response = self.client.post(self.registration_path,
+                                    data=data1,
+                                    format='json')
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+
+        response = self.client.post(self.registration_path,
+                                    data=data2,
+                                    format='json')
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)

--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -59,6 +59,21 @@ class RegistrationAPIView(APIView):
         # below is common and you will see it a lot throughout this course and
         # your own work later on. Get familiar with it.
 
+        try:
+            if User.objects.get(email=user['email']):
+                return Response({"error": "a user with that email exists"},
+                                status.HTTP_409_CONFLICT)
+        except User.DoesNotExist:
+            pass
+
+        try:
+            if User.objects.get(username=user['username']):
+                return Response({"error": "a user with that username "
+                                          "exists"},
+                                status.HTTP_409_CONFLICT)
+        except User.DoesNotExist:
+            pass
+
         serializer = self.serializer_class(data=user)
         serializer.is_valid(raise_exception=True)
         serializer.save()


### PR DESCRIPTION
**What does this PR do?**
Adds validation to return 409 on duplicates

**Description of Task to be completed?**
- add validation to return 409 on duplicates

**How should this be manually tested?**
1. Clone the repo
```
$ git clone https://github.com/deferral/ah-django
```
2. Create a virtual environment with virtualenv
```
$ virtualenv venv
```
3. Configure the database to work with the application
```
$ python manage.py makemigrations
$ python manage.py migrate
```
4. Run the application
```
$ python manage.py runserver
```
5. Test the routes `POST /articles/` with a duplicate title, or `POST /signup/` with duplicate username/title

**Any background context you want to provide?**

**What are the relevant pivotal tracker stories?**
[#165631652](https://www.pivotaltracker.com/n/projects/2321584/stories/165631652)