### PR TITLE
#167251077 fix reset password link

### DIFF
--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -1,22 +1,18 @@
 from django.conf.urls import url
 from django.urls.conf import path
 
-from .views import (
-    ArticleList, ArticleDetails, NewArticle, RateArticle,
-    SearchArticlesList, ReadArticleView, ShareArticlesApiView,
-    ReportArticleView, ReportList, ReportAPIViews
-)
-
+from .views import (ArticleList, ArticleDetails, NewArticle, RateArticle,
+                    SearchArticlesList, ReadArticleView, ShareArticlesApiView,
+                    ReportArticleView, ReportList, ReportAPIViews,
+                    UserArticlesList)
 
 app_name = 'articles'
 
-urlpatterns = [
-    url(r'^articles/search',
-        SearchArticlesList.as_view(), name='article_title'),
+urlpatterns = [url(r'^articles/search', SearchArticlesList.as_view(),
+                   name='article_title'),
     url(r'^articles/(?P<slug>.+)/report/$', ReportArticleView.as_view(),
         name='report_article'),
-    url(r'^articles/reports/$', ReportList.as_view(),
-        name='view_reports'),
+    url(r'^articles/reports/$', ReportList.as_view(), name='view_reports'),
     url(r'^articles/(?P<pk>.+)/action/$', ReportAPIViews.as_view(),
         name='report_actions'),
     url(r'^articles/$', NewArticle.as_view(), name='new_article'),
@@ -29,4 +25,5 @@ urlpatterns = [
         name='article_details'),
     path('articles/<slug:slug>/read', ReadArticleView.as_view(),
          name='read_article'),
-]
+    url(r'^user_articles/(?P<id>[0-9]+)/$', UserArticlesList.as_view(),
+        name='user_articles'), ]

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -1,5 +1,6 @@
 import cloudinary
 import imghdr
+import validators
 from rest_framework import generics, status, mixins, exceptions
 from rest_framework.permissions import (
     IsAuthenticated, IsAuthenticatedOrReadOnly,
@@ -78,6 +79,8 @@ class NewArticle(APIView):
                     article['image'], 'dvyip3rs',
                     public_id=article['slug'])
                 article['image'] = res['url']
+            elif validators.url(article['image']):
+                article['image'] = article['image']
             else:
                 return Response({"error": "image not found"},
                                 status=status.HTTP_400_BAD_REQUEST)
@@ -100,6 +103,18 @@ class ArticleList(generics.ListAPIView):
 
     queryset = Article.objects.all()
     serializer_class = ArticleSerializer
+
+
+class UserArticlesList(generics.ListAPIView):
+    queryset = Article.objects.all()
+    serializer_class = ArticleSerializer
+    lookup_field = "id"
+
+    def list(self, request, id, *args, **kwargs):
+        posts = Article.objects.filter(author=id)
+
+        serializer = self.serializer_class(posts, many=True)
+        return Response(serializer.data)
 
 
 class ArticleDetails(generics.RetrieveAPIView, mixins.UpdateModelMixin,

--- a/authors/apps/authentication/serializers.py
+++ b/authors/apps/authentication/serializers.py
@@ -104,7 +104,8 @@ class LoginSerializer(serializers.Serializer):
         # that we will see later on.
         return {
             'username': user.username,
-            'token': token
+            'token': token,
+            'user_id': user.id,
         }
 
 

--- a/authors/apps/authentication/tests/base_test.py
+++ b/authors/apps/authentication/tests/base_test.py
@@ -126,14 +126,13 @@ class BaseTestCase(APITestCase):
 
         self.facebook_social_auth = {
             "token_provider": "facebook",
-            "access_token": 'EAAGCNgo8jC4BACqTMo' +
-                            '272cv6RQzDgVPzwKAb1ppiL6' +
-                            'UTg37ZBCJKVEqg3Vn9YfBGxD' +
-                            'sGFg4hc3IydIzxQ2cxzN5kn' +
-                            'SQlOeaa6s4iMFL6z3zik1G7' +
-                            'SERGJ40ZB2XAOaFKcRttNGc' +
-                            'pr4BMKnavMKi9F1VDZC46TW' +
-                            'hRZBsTHc30L2nh85VehTHn'
+            "access_token": 'EAAGCNgo8jC4BAF6tYZBO4gVq11U' +
+                            'rn7FPsFoUBiO7ZBXKoSmhSOUn3aQ' +
+                            'WcVU5kpoQO5AWbdm2ooSW6UCYU' +
+                            'ps5SjUs5JZCkpQyHkqQ4UEQ1cn8' +
+                            'lbSwmSXDZCAh8DsfQD' +
+                            'TR64OUz8bzZBIdjU4Srfu' +
+                            '7yo7Q65dTwTO86lcNWc44wyt41tqQ6sPhQ'
         }
 
         self.facebook_social_wrong_auth = {

--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -132,6 +132,7 @@ class LoginAPIView(APIView):
             logs the user into the system
         """
         user = request.data.get('user', {})
+        user_id = User.objects.get(username=user["username"])
 
         # Notice here that we do not call `serializer.save()` like we did for
         # the registration endpoint. This is because we don't actually have
@@ -139,8 +140,10 @@ class LoginAPIView(APIView):
         # handles everything we need.
         serializer = self.serializer_class(data=user)
         serializer.is_valid(raise_exception=True)
+        serialized_data = serializer.data
+        serialized_data["user_id"] = user_id.id
 
-        return Response(serializer.data, status=status.HTTP_200_OK)
+        return Response(serialized_data, status=status.HTTP_200_OK)
 
 
 class VerifyUserAPIView(RetrieveAPIView):

--- a/authors/apps/core/client.py
+++ b/authors/apps/core/client.py
@@ -14,5 +14,6 @@ def get_password_reset_link(request, token):
     client_url refers to the front-end application reset url
     e.g http://ah-django/deferral/reset-password
     """
-    domain = get_current_site(request).domain
-    return 'http://{}/api/account/reset_password/{}'.format(domain, token)
+
+    front_end_domain = os.getenv('FRONTEND_DOMAIN')
+    return 'http://{}/{}'.format(front_end_domain, token)

--- a/authors/apps/followers/tests/base_test.py
+++ b/authors/apps/followers/tests/base_test.py
@@ -1,8 +1,8 @@
 from django.urls import reverse
-
+from rest_framework_jwt.compat import get_user_model
 from rest_framework.test import APITestCase, APIClient
 
-
+User = get_user_model()
 class FollowerBaseTest(APITestCase):
     """
     A base test containing for followers tests file
@@ -22,7 +22,7 @@ class FollowerBaseTest(APITestCase):
             "user": {
                 "username": "testuser",
                 "email": "test@this.com",
-                "password": "testT23#$"
+                "password": "testT23#!"
             }
         }
 
@@ -45,21 +45,21 @@ class FollowerBaseTest(APITestCase):
         self.client = APIClient()
         self.registration_path = reverse('authentication:activation')
         self.login_path = reverse('authentication:login')
-        self.follow_url = reverse('followers:follow_url', kwargs={
-            "username": self.followed_user['username']}
-        )
-        self.follow_self_url = reverse('followers:follow_url', kwargs={
-            "username": self.follow_self['username']}
-        )
-        self.unfollow_url = reverse('followers:delete_url', kwargs={
-            "username": self.followed_user['username']
-        })
-        self.following_list_url = reverse('followers:following_url', kwargs={
-            "username": self.followed_user['username']
-        })
-        self.followers_url = reverse('followers:followers_url', kwargs={
-            "username": self.follow_user['username']
-        })
+        # self.follow_url = reverse('followers:follow_url', kwargs={
+        #     "user_id": self.user_id})
+
+        # self.follow_self_url = reverse('followers:follow_url', kwargs={
+        #     "user_id": self.user_id})
+
+        # self.unfollow_url = reverse('followers:delete_url', kwargs={
+        #     "user_id": self.user_id
+        # })
+        # self.following_list_url = reverse('followers:following_url', kwargs={
+        #     "user_id": self.user_id
+        # })
+        # self.followers_url = reverse('followers:followers_url', kwargs={
+        #     "user_id": self.user_id
+        # })
 
     def register_user(self, data):
         return self.client.post(

--- a/authors/apps/followers/urls.py
+++ b/authors/apps/followers/urls.py
@@ -5,12 +5,12 @@ from .views import FollowersView, RetrieveFollowing
 app_name = 'followers'
 
 urlpatterns = [
-    url(r'^profiles/?(?P<username>[a-zA-Z0-9_\.-]{3,255})?/?/follow/?$',
+    url(r'^profiles/?/(?P<user_id>[\d]+)?/?/follow/?$',
         ListCreateFollow.as_view(), name='follow_url'),
-    url(r'^profiles/?(?P<username>[a-zA-Z0-9_\.-]{3,255})?/?/unfollow',
+    url(r'^profiles/?/(?P<user_id>[\d]+)?/?/unfollow',
         DeleteFollower.as_view(), name='delete_url'),
-    url(r'^profiles/?(?P<username>[a-zA-Z0-9_\.-]{3,255})?/?/followers/',
+    url(r'^profiles/?/(?P<user_id>[\d]+)?/?/followers/',
         FollowersView.as_view(), name='followers_url'),
-    url(r'^profiles/?(?P<username>[a-zA-Z0-9_\.-]{3,255})?/?/following/',
+    url(r'^profiles/?/(?P<user_id>[\d]+)?/?/following/',
         RetrieveFollowing.as_view(), name='following_url'),
 ]

--- a/authors/apps/followers/views.py
+++ b/authors/apps/followers/views.py
@@ -16,7 +16,7 @@ from rest_framework.response import Response
 
 def user_not_found():
     raise ValidationError(
-        {'error': 'User with that username not found'})
+        {'error': 'User with that user_id not found'})
 
 
 class ListCreateFollow(ListCreateAPIView):
@@ -25,17 +25,17 @@ class ListCreateFollow(ListCreateAPIView):
     permission_classes = (IsAuthenticated,)
     renderer_classes = (FollowerJsonRenderer,)
 
-    def post(self, request, username):
+    def post(self, request, user_id):
         """
         A method for following a user
         """
-        user_exists = User.objects.filter(username=username).exists()
+        user_exists = User.objects.filter(id=user_id).exists()
         if not user_exists:
             return Response(
                 {'error': 'user with that name was not found'},
                 status.HTTP_404_NOT_FOUND)
         # we check if the user is already followed
-        followed_user = User.objects.get(username=username)
+        followed_user = User.objects.get(id=user_id)
         already_followed = Follow.is_user_already_followed(
             followed_user_id=followed_user.id,
             user_id=self.request.user.id
@@ -67,8 +67,8 @@ class FollowersView(ListCreateAPIView):
     renderer_classes = (FollowerListJsonRenderer,)
 
     def get(self, request, **kwargs):
-        username = kwargs.get('username')
-        user = User.objects.filter(username=username).first()
+        user_id = kwargs.get('user_id')
+        user = User.objects.filter(id=user_id).first()
         if not user:
             user_not_found()
         queryset = Follow.objects.filter(followed_user=user)
@@ -84,15 +84,15 @@ class DeleteFollower(DestroyAPIView):
     serializer_class = FollowerSerializer
     permission_classes = (IsAuthenticatedOrReadOnly, IsOwnerOrReadOnly)
 
-    def delete(self, request, username):
+    def delete(self, request, user_id):
         """
         Removes a user from following list
         """
-        followed_user_exists = User.objects.filter(username=username).exists()
+        followed_user_exists = User.objects.filter(id=user_id).exists()
         if not followed_user_exists:
             return Response({'error': 'user not found'},
                             status.HTTP_404_NOT_FOUND)
-        followed_user = User.objects.get(username=username)
+        followed_user = User.objects.get(id=user_id)
         user_exists = Follow.is_user_already_followed(
             followed_user_id=followed_user.id,
             user_id=request.user.id
@@ -119,11 +119,11 @@ class RetrieveFollowing(ListCreateAPIView):
     permission_classes = (IsAuthenticated,)
 
     def get(self, request, **kwargs):
-        username = kwargs.get('username')
+        user_id = kwargs.get('user_id')
         """
-        Get userlist by using the username value
+        Get userlist by using the user_id value
         """
-        user = User.objects.filter(username=username).first()
+        user = User.objects.filter(id=user_id).first()
         if not user:
             user_not_found()
         following_list = Follow.objects.filter(user=user)

--- a/authors/apps/reactions/helpers.py
+++ b/authors/apps/reactions/helpers.py
@@ -33,6 +33,7 @@ class DisLikeReaction:
         """
 
         self.reaction = inherited_react
+        self.article_liked = False
 
         try:
             like_status = UserReaction.objects.get(
@@ -54,6 +55,7 @@ class DisLikeReaction:
             instance.user_reaction.create(
                 user_reaction=self.reaction,
                 user=user)
+            self.article_liked = True
             msg = "Reaction Created"
             status_ = status.HTTP_201_CREATED
 
@@ -66,7 +68,8 @@ class DisLikeReaction:
             'dislikes': instance.
             user_reaction.dislikes.count(),
             'participated_users': instance.
-            user_reaction.fetch_popularity_status()
+            user_reaction.fetch_popularity_status(),
+            'article_liked': self.article_liked
         }
         response['data'] = data
 

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -178,7 +178,7 @@ REST_FRAMEWORK = {
 
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination'
                                 '.PageNumberPagination',
-    'PAGE_SIZE': 5
+    'PAGE_SIZE': 10
 }
 
 EMAIL_BACKEND = 'sendgrid_backend.SendgridBackend'
@@ -219,7 +219,7 @@ JWT_AUTH = {
         'JWT_VERIFY': True,
         'JWT_VERIFY_EXPIRATION': True,
         'JWT_LEEWAY': 0,
-        'JWT_EXPIRATION_DELTA': datetime.timedelta(hours=3),
+        'JWT_EXPIRATION_DELTA': datetime.timedelta(days=17),
         'JWT_AUDIENCE': None,
         'JWT_ISSUER': None,
         'JWT_ALLOW_REFRESH': False,

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ coverage==4.5.3
 coveralls==1.7.0
 cssutils==1.0.2
 daphne==2.3.0
+decorator==4.4.0
 defusedxml==0.5.0
 dj-database-url==0.5.0
 Django==2.0.8
@@ -117,6 +118,7 @@ txaio==18.8.1
 typed-ast==1.3.1
 uritemplate==3.0.0
 urllib3==1.24.1
+validators==0.13.0
 virtualenv==16.4.3
 whitenoise==4.1.2
 wrapt==1.11.1


### PR DESCRIPTION
#### What does this PR do?
- fixed reset password link

#### Description of Task to be completed?
 - [x] fixed reset password link

#### How should this be manually tested?
- Clone the repo to your local machine from here

- cd into the ah-django directory and checkout to the branch `ft-reset-password-viaemail-164859749`

- `cd ah-django`

- `git checkout ft-reset-password-viaemail-164859749`

- Create a virtual environment and activate it:

- `python3 -m virtualenv venv && source venv/bin/activate`

- If you need to install virtualenv first:

`pip install virtualenv`

`Install the project dependencies`

`pip install -r requirements.txt`

- Make database migrations and start the django server

- python3 manage.py makemigrations

- python3 manage.py migrate

- python3 manage.py runserver

- signup as a new user using a valid email

- try changing passing using the signed up email as the input

- check your inbox to find the send link and click on it to reset the password

- for receiving a reset link provide the data to postman in this format:

  ``` {
   "email": "test.user@gmail.com"
   }```
- for resetting the password provide the data to postman in this format:

  ``` {
     "password": "mYp@55ord"
     "password": "mYp@55ord"
   }```
- request type POST

#### Any background context you want to provide?
- Initially, the application had no reset password endpoint

#### What are the relevant pivotal tracker stories?
#167251077